### PR TITLE
Delegate search

### DIFF
--- a/qa-behavior/v1/qa-behavior.html
+++ b/qa-behavior/v1/qa-behavior.html
@@ -15,7 +15,7 @@
 				.replace('_', ' ');
 		},
 		toClassName: function(value) {
-			value = value.trim()
+			value = String(value).trim()
 				.replace(/([a-z])([A-Z])/g, '$1-$2')
 				.replace(/[\s_]/g, '-')
 				.toLowerCase();
@@ -46,6 +46,15 @@
 					result.slice(match.index + 1);
 			}
 			return result;
+		},
+		getParameterByName: function(name) {
+			var url = window.location.href;
+			name = name.replace(/[\[\]]/g, "\\$&");
+			var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+			results = regex.exec(url);
+			if (!results) return null;
+			if (!results[2]) return '';
+			return decodeURIComponent(results[2].replace(/\+/g, " "));
 		}
 	};
 

--- a/qa-header/v3/qa-header.html
+++ b/qa-header/v3/qa-header.html
@@ -2,8 +2,6 @@
 <link rel="import" href="../../../bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="../../../bower_components/paper-tabs/paper-tab.html">
 <link rel="import" href="../../../bower_components/iron-image/iron-image.html">
-<link rel="import" href="../../../bower_components/iron-ajax/iron-ajax.html">
-<link rel="import" href="../../qa-search/v2/qa-search.html">
 <link rel="import" href="../../qa-styles/v1/qa-styles.html">
 
 <dom-module id="qa-header">
@@ -26,9 +24,6 @@
 				opacity: 0.8;
 				font-size: 18px;
 			}
-			qa-search {
-				width: 440px;
-			}
 			paper-tab {
 				--paper-tab-ink: var(--qa-text-color);
 				--paper-tab: {
@@ -39,24 +34,18 @@
 			}
 		</style>
 		<iron-image alt="Quinto Andar" src="https://d406l28ic3dl5.cloudfront.net/5a-logo.svg"></iron-image>
-		<paper-tabs selected="{{selectedIndex}}" no-bar>
+		<paper-tabs no-bar>
 			<template is="dom-repeat" items="[[views]]">
-				<paper-tab>{{item.label}}</paper-tab>
+				<paper-tab on-tap="onTapTab">{{item.label}}</paper-tab>
 			</template>
 		</paper-tabs>
 		<div class="layout horizontal flex center-justified">
-			<qa-search></qa-search>
+			<content></content>
 		</div>
 		<div class="user">
 			<div>{{user.name}}</div>
 			<div>{{user.email}}</div>
 		</div>
-		<iron-ajax
-			auto
-			url="@@USTASKS_URL/views.json"
-			last-response="{{views}}"
-			with-credentials>
-		</iron-ajax>
 	</template>
 
 	<script src="../../../bower_components/jwt-decode/build/jwt-decode.min.js"></script>
@@ -67,20 +56,44 @@
 			is: "qa-header",
 			properties: {
 				user: Object,
-				selectedView: String,
-				selectedIndex: {
-					type: Number,
-					observer: 'onSelect'
+				selectedView: {
+					type: String,
+					value: ''
 				},
 				views: {
 					type: Array,
 					value: function() {
-						return [];
+						return [{
+							id: 'ustasks',
+							label: 'Tarefas',
+							url: '@@USTASKS_URL'
+						}, {
+							id: 'properties',
+							label: 'Imóveis',
+							url: '@@PROPERTIES_URL/busca'
+						}, {
+							id: 'accounts',
+							label: 'Clientes',
+							url: '@@ACCOUNTS_URL/busca'
+						}, {
+							id: 'reports',
+							label: 'Relatórios',
+							url: '@@USTASKS_URL/relatorios'
+						}];
 					}
 				}
 			},
-			onSelect: function(index) {
-				window.open(this.views[index].url, '_blank');
+			observers: [ 'selectView(selectedView, views)' ],
+			selectView: function() {
+				this.views.forEach(function(view, index) {
+					if (view.id == this.selectedView) {
+						this.$$('paper-tabs').select(index);
+					}
+				}, this);
+			},
+			onTapTab: function(event) {
+				window.open(event.model.item.url, '_blank');
+				this.async(this.selectView, 1);
 			},
 			ready: function() {
 				var token = document.cookie

--- a/qa-loading/v1/qa-loading.html
+++ b/qa-loading/v1/qa-loading.html
@@ -9,6 +9,8 @@
 			:host {
 				@apply(--layout-vertical);
 				@apply(--layout-flex);
+				position: relative;
+				min-height: 32px;
 			}
 			.message, .frame {
 				text-align: center;
@@ -17,13 +19,17 @@
 			.message a {
 				font-size: 0.86em;
 			}
+			.overlay {
+				@apply(--layout-fit);
+				background-color: rgba(255, 255, 255, 0.5);
+			}
 		</style>
 		<template is="dom-if" if="[[loading]]">
-			<div class="frame">
+			<div class$="frame [[getOverlayClass(withOverlay)]]">
 				<paper-spinner-lite active="[[loading]]"></paper-spinner-lite>
 			</div>
 		</template>
-		<template is="dom-if" if="[[!loading]]">
+		<template is="dom-if" if="[[alwaysShowContent(loading, withOverlay)]]">
 			<template is="dom-if" if="[[showContent(isEmpty, error)]]">
 				<div>
 					<content></content>
@@ -46,6 +52,10 @@
 		Polymer({
 			is: "qa-loading",
 			properties: {
+				withOverlay: {
+					type: Boolean,
+					value: false
+				},
 				loader: {
 					type: HTMLElement,
 					observer: 'onLoaderChange'
@@ -76,6 +86,12 @@
 				console.log('qa-loading.message is deprecated');
 				this.set('messageForEmptyState', message);
 				this.set('isEmpty', Boolean(message.length));
+			},
+			alwaysShowContent: function(loading, withOverlay) {
+				return withOverlay || !loading;
+			},
+			getOverlayClass: function(withOverlay) {
+				return withOverlay ? 'overlay' : '';
 			},
 			onLoaderChange: function(loader) {
 				if (this._oldLoader) {

--- a/qa-pager/v1/qa-pager.html
+++ b/qa-pager/v1/qa-pager.html
@@ -1,60 +1,55 @@
 <link rel="import" href="../../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../../bower_components/iron-selector/iron-selector.html">
+<link rel="import" href="../../qa-styles/v1/qa-styles.html">
+<link rel="import" href="../../qa-badge/v1/qa-badge.html">
 
 <dom-module id="qa-pager">
 
 	<template>
-	<style include="iron-flex iron-flex-alignment"></style>
-	<style is="custom-style">
-	iron-selector {
-		margin: 16px 0px;
-	}
-	.page {
-		background-color: #008CE1;
-		border-radius: 3px;
-		text-align: center;
-		color: white;
-		width: 24px;
-		height: 24px;
-	}
-	.page:not(:last-of-type) {
-		margin-right: 4px;
-	}
-	.iron-selected {
-		color: #008CE1;
-		background-color: #DFEFF4;
-	}
-	</style>
-	<iron-selector selected="{{page}}" class="pages layout end-justified horizontal">
-		<template is="dom-repeat" items="{{pageArray}}">
-			<div class="page layout vertical center-justified">{{item}}</div>
-		</template>
-	</iron-selector>
+		<style include="iron-flex iron-flex-alignment"></style>
+		<style include="qa-styles"></style>
+		<style is="custom-style">
+			qa-badge {
+				cursor: pointer;
+				font-size: 12px;
+				min-width: 0px;
+				margin: 0 0 0 0.4em;
+				background-color: var(--qa-color);
+			}
+			qa-badge:hover {
+				background-color: var(--qa-light-color);
+			}
+			qa-badge.iron-selected {
+				background-color: var(--qa-dark-color);
+			}
+		</style>
+		<iron-selector selected="{{page}}" class="pages layout end-justified horizontal">
+			<template is="dom-repeat" items="[[getPageArray(pages)]]">
+				<qa-badge label="[[item]]" full></qa-badge>
+			</template>
+		</iron-selector>
 	</template>
 
 	<script>
 
-	Polymer({
-		is: "qa-pager",
-		properties: {
-			pages: {
-				type: Number,
-				value: 10
+		Polymer({
+			is: "qa-pager",
+			properties: {
+				pages: {
+					type: Number,
+					value: 0
+				},
+				page: {
+					type: Number,
+					notify: true,
+					value: 0
+				}
 			},
-			page: {
-				type: Number,
-				value: 1,
-				notify: true
-			},
-			pageArray: {
-				computed: 'getPageArray(pages)'
+			getPageArray: function(pages) {
+				return Array.apply(null, Array(pages)).map(function(item, index) {
+					return index + 1;
+				});
 			}
-		},
-		getPageArray: function(pages) {
-			return Array.apply(null, Array(pages)).map(function(item, index) {
-				return index + 1;
-			});
-		}
-	});
+		});
 	</script>
 </dom-module>

--- a/qa-search/v2/qa-search.html
+++ b/qa-search/v2/qa-search.html
@@ -278,11 +278,9 @@
 				this.doRequest();
 			},
 			getParams: function(value, delegating, page, size, selectedType) {
-				return {
-					query: value,
-					size: delegating ? size : selectedType.size,
-					page: delegating ? page : 0
-				};
+				size = delegating ? size : selectedType.size;
+				var offset = size * (delegating ? page : 0);
+				return { query: value, size: size, offset: offset };
 			},
 			onPageChange: function(page) {
 				this.doRequest();

--- a/qa-search/v2/qa-search.html
+++ b/qa-search/v2/qa-search.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../../../bower_components/iron-dropdown/iron-dropdown.html">
 <link rel="import" href="../../../bower_components/iron-ajax/iron-ajax.html">
 <link rel="import" href="../../../bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="../../../bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="../../../bower_components/paper-item/paper-icon-item.html">
 <link rel="import" href="../../../bower_components/paper-menu/paper-menu.html">
 <link rel="import" href="../../../bower_components/paper-menu-button/paper-menu-button.html">
@@ -25,6 +26,7 @@
 			:host {
 				@apply(--layout-horizontal);
 				@apply(--layout-center);
+				width: 480px;
 			}
 			#menu {
 				background-color: var(--qa-darker-color);
@@ -144,10 +146,9 @@
 		</iron-dropdown>
 		<iron-ajax
 			id="ajax"
-			auto="[[value]]"
 			url="/api/search"
-			params="[[getParams(value, selectedType)]]"
-			last-response="{{result}}"
+			params="[[getParams(value, delegating, page, size, selectedType)]]"
+			loading="{{isLoading}}"
 			on-request="onRequest"
 			on-response="onResponse"
 			on-error="onResponse"
@@ -158,7 +159,43 @@
 		Polymer({
 			is: 'qa-search',
 			properties: {
-				value: String,
+				value: {
+					type: String,
+					value: ''
+				},
+				delegateType: {
+					type: String,
+					value: ''
+				},
+				delegateValue: {
+					type: String,
+					observer: 'onDelegateValueChange',
+					notify: true
+				},
+				delegateResult: {
+					type: Object,
+					notify: true
+				},
+				delegating: {
+					type: Boolean,
+					computed: 'isDelegating(selectedType, delegateType)'
+				},
+				isLoading: Boolean,
+				loading: {
+					type: Boolean,
+					notify: true,
+					computed: 'getLoading(isLoading, delegating)'
+				},
+				page: {
+					type: Number,
+					notify: true,
+					value: 0,
+					observer: 'onPageChange'
+				},
+				size: {
+					type: Number,
+					value: 10
+				},
 				result: Object,
 				selectedType: Object,
 				selectedTypeIndex: {
@@ -169,18 +206,21 @@
 					type: Array,
 					value: function() {
 						return [{
+							id: 'all',
 							size: 4,
 							label: 'Todos',
 							showPeople: true,
 							showProperties: true,
 							icon: this.resolveUrl('../v1/assets/magnifier12.png')
 						}, {
+							id: 'users',
 							size: 10,
 							label: 'Pessoas',
 							showPeople: true,
 							showProperties: false,
 							icon: this.resolveUrl('../v1/assets/social10.png')
 						}, {
+							id: 'properties',
 							size: 10,
 							label: 'Imoveis',
 							showPeople: false,
@@ -194,37 +234,94 @@
 			listeners: {
 				'iron-resize': 'onResize'
 			},
-			observers: [ 'onSelectType(types, selectedTypeIndex, value)' ],
-			onSelectType: function(types, selectedTypeIndex, value) {
+			observers: [
+				'onDelegate(types, delegateType, page)',
+				'onSelectType(types, selectedTypeIndex)'
+			],
+			onSelectType: function(types, selectedTypeIndex) {
 				this.set('selectedType', types[selectedTypeIndex]);
-				if (value) {
-					this.$.ajax.generateRequest();
+				if (this.delegating && this.delegateValue) {
+					this.set('value', this.delegateValue);
+				} else {
+					this.doRequest();
 				}
 			},
-			getParams: function(value, selectedType) {
-				return { query: value, size: selectedType.size };
+			doRequest: function() {
+				if (this.value.length > 2) {
+					this.async(function() {
+						this.$.ajax.generateRequest();
+					});
+					return true;
+				} else {
+					return false;
+				}
+			},
+			onDelegate: function(types, delegateType, page) {
+				/* page is here to force the
+				 * delegated type on page change */
+				types.forEach(function(type, index) {
+					if (type.id == delegateType) {
+						this.set('selectedTypeIndex', index);
+					}
+				}, this);
+			},
+			onDelegateValueChange: function(value) {
+				if (this.value == value) {
+					return;
+				}
+				this.set('value', value);
+				this.doRequest();
+			},
+			getParams: function(value, delegating, page, size, selectedType) {
+				return {
+					query: value,
+					size: delegating ? size : selectedType.size,
+					page: delegating ? page : 0
+				};
+			},
+			onPageChange: function(page) {
+				this.doRequest();
+			},
+			isDelegating: function(selectedType, delegateType) {
+				return selectedType.id == delegateType;
+			},
+			getLoading: function(isLoading, delegating) {
+				return isLoading && delegating;
 			},
 			onKeydown: function(event) {
-				if (event.target.value.length && event.keyCode == 13) {
-					this.$.ajax.generateRequest();
+				if (event.keyCode == 13) {
+					this.doRequest();
 				}
 			},
 			onInput: function(event) {
-				if (!event.target.value.length) {
+				var value = event.target.value;
+				if (this.doRequest()) {
 					this.$.dropdown.close();
+				}
+				if (this.delegating) {
+					this.set('delegateValue', value);
+					this.set('page', 0);
 				}
 			},
 			onRequest: function() {
-				this.$.dropdown.open();
+				if (this.selectedType.id != this.delegateType) {
+					this.$.dropdown.open();
+				}
 			},
 			onResize: function() {
 				this.$$('paper-menu-button').verticalOffset = this.offsetHeight;
 				this.$.dropdown.style.minWidth = this.offsetWidth + 'px';
 			},
-			onResponse: function() {
-				this.async(function() {
-					this.$.dropdown.notifyResize();
-				});
+			onResponse: function(event) {
+				var response = event.detail.response;
+				if (this.delegating) {
+					this.set('delegateResult', response[this.selectedType.id]);
+				} else {
+					this.set('result', response);
+					this.async(function() {
+						this.$.dropdown.notifyResize();
+					});
+				}
 			},
 			getMessage: function(type, value, count) {
 				if (count) {
@@ -248,5 +345,4 @@
 
 	</script>
 </dom-module>
-
 

--- a/qa-search/v2/qa-search.html
+++ b/qa-search/v2/qa-search.html
@@ -180,6 +180,11 @@
 					type: Boolean,
 					computed: 'isDelegating(selectedType, delegateType)'
 				},
+				minLength: {
+					type: Number,
+					notify: true,
+					value: 3
+				},
 				isLoading: Boolean,
 				loading: {
 					type: Boolean,
@@ -247,7 +252,7 @@
 				}
 			},
 			doRequest: function() {
-				if (this.value.length > 2) {
+				if (this.value.length >= this.minLength) {
 					this.async(function() {
 						this.$.ajax.generateRequest();
 					});


### PR DESCRIPTION
Como o componente de search acaba conhecendo e fazendo tudo relacionado a busca, fez mais sentido centralizar nele toda lógica da busca e apenas delegar o resultados para a página de apresentação.

Antes desta implementação, as páginas de imóveis e accounts basicamente reimplementava todo o código esse código =/

Este patch set tbm:
- permite que o qaLoading continue a mostrar o conteúdo da página enquanto "carregando";
- hardcoda no qaHeader as urls das views eliminado a necessidade do views.json e os erros de CORS.