### PR TITLE
Corrigindo o calendário para datas vazias

### DIFF
--- a/qa-form/v2/qa-datepicker.html
+++ b/qa-form/v2/qa-datepicker.html
@@ -150,10 +150,11 @@
 			_onChangeValue: function(value, format) {
 				moment.locale('pt-br');
 				var date = moment(value, format);
-				if (date.isValid()) {
-					this._setSelected(date.format());
-					this._setDate(date.format());
+				if (!date.isValid()) {
+					date = moment();
 				}
+				this._setSelected(date.format());
+				this._setDate(date.format());
 			},
 			_getDate: function(date) {
 				moment.locale('pt-br');
@@ -239,4 +240,3 @@
 		});
 	</script>
 </dom-module>
-


### PR DESCRIPTION
No componente `qa-input-date`, se o valor do input estiver em branco, o calendário do `qa-datepicker` abre vazio, como na imagem abaixo:
![image](https://cloud.githubusercontent.com/assets/2348079/19566160/077e8350-96c8-11e6-9411-dc86fc20ee44.png)

Alterei o `qa-date-picker` para usar a data atual, caso o input esteja em branco.