### PR TITLE
Fix onboarding comments

### DIFF
--- a/qa-history/v1/qa-history.html
+++ b/qa-history/v1/qa-history.html
@@ -187,7 +187,7 @@
 					return [];
 				}
 
-				tags = [].concat(tags, content.root.tag);
+				tags = [].concat(content.root.tag, tags);
 
 				const allLinks = [].concat(links);
 				const uniqueTags = Array.from(new Set(tags));


### PR DESCRIPTION
Only the first tag is indexed and it must be the fluxodelocacao tag. That tag is in the `content.root.tag` variable.