### PR TITLE
fixing tasktitle fields clear

### DIFF
--- a/qa-task-creation-dialog/qa-task-creation-dialog.html
+++ b/qa-task-creation-dialog/qa-task-creation-dialog.html
@@ -413,11 +413,17 @@
 			},
 			resetTaskTitles: function(){
 				this.taskTitles = this.filterTaskTitles(this.workgroupIndex, this.workgroups, this.allTaskTitles);
+				
+				var combobox = document.querySelector('#taskTitleBox');
+				combobox._clear();
 			},
 			selectDefaultTaskDescription: function(){
 				var combobox = document.querySelector('#taskTitleBox');
 				if(combobox != null && combobox.value != "" && combobox.selectedItem != null && combobox.selectedItem.desc.length > 0){
 					this.description = combobox.selectedItem.desc;
+				}
+				else{
+					this.description = null;
 				}
 			},
 			open: function() {


### PR DESCRIPTION
When a new workgroups is selected, both "Description" and "TaskTitle" fields will be cleared.
When a new Task is selected and this new task has no "default" description, the description field will be set to "null"