### PR TITLE
adding fire to event to update current task on single task view

### DIFF
--- a/qa-dialog/v2/dialog-form-behavior.html
+++ b/qa-dialog/v2/dialog-form-behavior.html
@@ -54,6 +54,7 @@
 			});
 			form.addEventListener('iron-form-response', function(e) {
 				self.fire('update-task');
+				self.fire('update-current-task');
 				self.close();
 			});
 		},

--- a/qa-link/v1/qa-link.html
+++ b/qa-link/v1/qa-link.html
@@ -195,6 +195,7 @@
 				request.send(params)
 				.then(function() {
 					this.fire('update-task');
+					this.fire('update-current-task');
 					this.fire('toast-show', {
 						id: this.toastId,
 						text: link.success || 'Feito'


### PR DESCRIPTION
This PR is related to the changes done on single task page on crm. When a task is snoozed, discarded or marked as done, an event will be tiggered in order to retrieve the new active task.